### PR TITLE
change to use FilePath to work on remote nodes

### DIFF
--- a/src/main/java/com/dg/watcher/validation/InputValidation.kt
+++ b/src/main/java/com/dg/watcher/validation/InputValidation.kt
@@ -4,8 +4,6 @@ import com.dg.watcher.base.Project
 import hudson.util.FormValidation
 import hudson.util.FormValidation.error
 import hudson.util.FormValidation.ok
-import java.io.File
-import java.io.File.separator
 
 
 fun validateThresholdInMb(input: String): FormValidation =
@@ -34,7 +32,7 @@ fun validateCustomPathToApk(input: String, project: Project): FormValidation =
 private fun noPathSpecified(input: String) = input.isBlank()
 
 private fun validPathSpecified(input: String, project: Project) =
-        File(getWorkSpaceRoot(project) + input).exists()
+        getWorkSpaceRoot(project)?.child(input)?.exists() == true
 
 private fun getWorkSpaceRoot(project: Project) =
-        project.getSomeWorkspace().toString() + separator
+        project.getSomeWorkspace()

--- a/src/main/java/com/dg/watcher/watching/loading/ApkLoading.kt
+++ b/src/main/java/com/dg/watcher/watching/loading/ApkLoading.kt
@@ -3,32 +3,29 @@ package com.dg.watcher.watching.loading
 import com.dg.watcher.base.APK_DEFAULT_DIR
 import com.dg.watcher.base.APK_EXTENSION
 import com.dg.watcher.base.Build
-import org.apache.commons.io.FileUtils.listFiles
-import java.io.File
-import java.io.File.separator
+import hudson.FilePath
 
 
 fun loadApk(build: Build, customApkDir: String = "") =
         loadApkFiles(getPathToApkDir(build, customApkDir)).firstOrNull()
 
-private fun getPathToApkDir(build: Build, customApkDir: String): String {
+private fun getPathToApkDir(build: Build, customApkDir: String): FilePath? {
     val workspaceDir = getWorkspaceDir(build)
 
     return if(customApkDir.isNotBlank()) {
-        workspaceDir + customApkDir
+        workspaceDir?.child(customApkDir)
     }
     else {
-        workspaceDir + APK_DEFAULT_DIR
+        workspaceDir?.child(APK_DEFAULT_DIR)
     }
 }
 
-private fun getWorkspaceDir(build: Build) = build.getWorkspace()?.remote + separator
+private fun getWorkspaceDir(build: Build) = build.getWorkspace()
 
-private fun loadApkFiles(pathToApkDir: String): List<File> {
-    val apkDirectory = File(pathToApkDir)
+private fun loadApkFiles(pathToApkDir: FilePath?): List<FilePath> {
 
-    return if(apkDirectory.exists()) {
-        listFiles(apkDirectory, arrayOf(APK_EXTENSION), false).toList()
+    return if(pathToApkDir?.exists() == true) {
+        pathToApkDir.list("*.$APK_EXTENSION").toList()
     }
     else {
         emptyList()

--- a/src/main/java/com/dg/watcher/watching/saving/SizeSaving.kt
+++ b/src/main/java/com/dg/watcher/watching/saving/SizeSaving.kt
@@ -1,13 +1,14 @@
 package com.dg.watcher.watching.saving
 
 import com.dg.watcher.base.*
+import hudson.FilePath
 import org.apache.commons.io.FileUtils.readFileToString
 import org.apache.commons.io.FileUtils.writeStringToFile
 import java.io.File
 import java.io.IOException
 
 
-fun saveApkSize(apk: File, build: Build) {
+fun saveApkSize(apk: FilePath, build: Build) {
     try {
         insertApkSize(apk, build)
     }
@@ -32,7 +33,7 @@ fun loadApkSizes(project: Project) =
         emptyList<SizeEntry>()
     }
 
-private fun insertApkSize(apk: File, build: Build) {
+private fun insertApkSize(apk: FilePath, build: Build) {
     val db = loadDatabase(build.getProject())
 
     writeStringToFile(db, createDatabaseRow(apk, build, db), DB_ENCODING, true)
@@ -40,11 +41,11 @@ private fun insertApkSize(apk: File, build: Build) {
 
 private fun loadDatabase(project: Project) = File(project.getRootDir().absolutePath + DB_FILE)
 
-private fun createDatabaseRow(apk: File, build: Build, db: File) = createRowSeparator(db) + createRowData(apk, build)
+private fun createDatabaseRow(apk: FilePath, build: Build, db: File) = createRowSeparator(db) + createRowData(apk, build)
 
 private fun createRowSeparator(database: File) = if(database.exists()) DB_ROW_SEPARATOR else ""
 
-private fun createRowData(apk: File, build: Build) = build.getDisplayName() + DB_COLUMN_SEPARATOR + apk.length()
+private fun createRowData(apk: FilePath, build: Build) = build.getDisplayName() + DB_COLUMN_SEPARATOR + apk.length()
 
 private fun loadRowsFromDatabase(database: File) =
     if(database.exists()) {

--- a/src/test/kotlin/com/dg/watcher/watching/loading/ApkLoadingTest.kt
+++ b/src/test/kotlin/com/dg/watcher/watching/loading/ApkLoadingTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.mock
 import hudson.FilePath
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -71,6 +72,16 @@ class ApkLoadingTest {
 
         // THEN
         assertNull(loadApk(mockBuild(), "apk_folder"))
+    }
+
+    @Test
+    fun `Should get a FilePath returned`() {
+        // GIVEN
+        createApkFolder("app", "build", "outputs", "apk")
+        createApkFile("app/build/outputs/apk", "debug.apk")
+
+        // THEN
+        assertTrue(loadApk(mockBuild()) is FilePath)
     }
 
     private fun createApkFolder(vararg folders: String) = tempDir.newFolder(*folders)

--- a/src/test/kotlin/com/dg/watcher/watching/saving/SizeSavingTest.kt
+++ b/src/test/kotlin/com/dg/watcher/watching/saving/SizeSavingTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
+import hudson.FilePath
 
 
 class SizeSavingTest {
@@ -52,7 +52,7 @@ class SizeSavingTest {
         whenever(getRootDir()).thenReturn(tempDir.root)
     }
 
-    private fun mockApkWithSizeInByte(sizeInByte: Long) = mock<File>().apply {
+    private fun mockApkWithSizeInByte(sizeInByte: Long) = mock<FilePath>().apply {
         whenever(length()).thenReturn(sizeInByte)
     }
 }


### PR DESCRIPTION
Changed all uses of `File` when referring to files within the workspace to use `FilePath` instead, so that it works properly with remote builder nodes.